### PR TITLE
Detect and install langues

### DIFF
--- a/nav-authsql/content/scripts/Install-Languages.ps1
+++ b/nav-authsql/content/scripts/Install-Languages.ps1
@@ -1,0 +1,27 @@
+$currDir = Split-Path $MyInvocation.MyCommand.Definition
+$dvdPath = "C:\install\content\DynamicsNavDvd\"
+$langMasterDirName = 'Installers'
+$langMasterDirPath = Join-Path $dvdPath $langMasterDirName
+$serviceDirName = 'Server'
+
+if (!(Test-Path $langMasterDirPath)) {
+    $langMasterDirPath
+    Write-Host "There is not the master language folder '"$langMasterDirName"' so exiting the language installation process."
+    return;
+}
+
+$langDirs = Get-ChildItem -Path $langMasterDirPath | Where-Object {$_.FullName -match "\b\w{2}\b"}
+
+foreach ($dir in $langDirs) {
+    Write-Host "Searching for language installer of the language" $dir.Name
+    $langPath = $dir.FullName
+
+    $serverInstallerPath =  Get-ChildItem -Path $langPath -Filter 'Server.Local.*.msi' -Recurse
+    if ($serverInstallerPath) {
+        Write-Host "Installing language from" $dir.Name", using installer file" $serverInstallerPath.FullName        
+        & (Join-Path $currDir Install-Msi.ps1) -MsiFullPath $serverInstallerPath.FullName
+        Write-Host "Language" $dir.Name "has beeen installed successfully" -ForegroundColor Green
+    } else {
+        Write-Host "Installer of the language" $dir.Name "probably doesn`t exist inside the folder" $langPath -ForegroundColor Red
+    }
+}

--- a/nav-authsql/content/scripts/Install-Msi.ps1
+++ b/nav-authsql/content/scripts/Install-Msi.ps1
@@ -14,4 +14,6 @@ while ($res.HasExited -eq $false) {
     Start-Sleep -s 1
 }
 
+Write-Host "EXIT CODE:" $res.ExitCode
+
 $exitCode = $res.ExitCode

--- a/nav-authsql/content/scripts/Install-ServiceTier.ps1
+++ b/nav-authsql/content/scripts/Install-ServiceTier.ps1
@@ -20,12 +20,13 @@ while ($res.HasExited -eq $false) {
     Start-Sleep -s 1
 }
 
+$exitCode = $res.ExitCode
+
 # Change service startup type to Disabled (we don`t want to run main and unconfigured default instance) and stop it.
+Write-Host "Trying stop and disable the default instance. Please, be patient, this may take a while." -ForegroundColor Green
 $navSvc = Get-Service '*MicrosoftDynamicsNavServer*' 
 Set-Service $navSvc.Name -StartupType Disabled
 Stop-Service $navSvc.Name
 
-# Copy missing dlls
-& (Join-Path $currDir Copy-ItemsTo.ps1) -ParentDirectory 'c:\install\content\ExtraDependencies' -FileNames $filesToCopy -TargetDirectory "c:\windows\system32"
-
-$exitCode = $res.ExitCode
+# Install languages
+& (Join-Path $currDir Install-Languages.ps1)


### PR DESCRIPTION
Added script and integrated into the build process script. This will
detect and install a language (if present) or multiple languages. All of
them must be placed in the folder "Installers" on NAV DVD (e.g.
"DynamicsNavDvd\Installers\ES\" ).

Some minor chanes (improvements).